### PR TITLE
Create recruiter role

### DIFF
--- a/src/controllers/authentication.js
+++ b/src/controllers/authentication.js
@@ -105,7 +105,7 @@ authenticationController.register = async function (req, res) {
         }
 
         if (!userData['account-type'] ||
-            (userData['account-type'] !== 'student' && userData['account-type'] !== 'instructor')) {
+            (userData['account-type'] !== 'student' && userData['account-type'] !== 'instructor' && userData['account-type'] !== 'recruiter')) {
             throw new Error('Invalid account type');
         }
 

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -188,6 +188,7 @@ Controllers.register = async function (req, res, next) {
                         <select class="form-control" name="account-type" aria-label="Account Type">
                             <option value="student" selected>Student</option>
                             <option value="instructor">Instructor</option>
+                            <option value="recruiter">Recruiter</option>
                         </select>
                     `,
                 },


### PR DESCRIPTION
Allow the creation of the "Recruiter" user account type during registration.
- Added Recruiter option to account type dropdown menu in registration page frontend
- Added Recruiter to list of valid account types to pass form validation
- Note: Account type field in user objects is a string and the registration page is a form object, so no additional work was needed to make recruiters on the backend

Resolves #7, #10 