### PR TITLE
Create company page from dropdown

### DIFF
--- a/public/openapi/read.yaml
+++ b/public/openapi/read.yaml
@@ -332,3 +332,5 @@ paths:
     $ref: 'read/groups/slug/members.yaml'
   /api/outgoing:
     $ref: 'read/outgoing.yaml'
+  /api/companies:
+    $ref: 'read/groups.yaml'

--- a/src/controllers/companies.js
+++ b/src/controllers/companies.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const validator = require('validator');
+const nconf = require('nconf');
+
+const meta = require('../meta');
+const groups = require('../groups');
+const user = require('../user');
+const helpers = require('./helpers');
+const pagination = require('../pagination');
+const privileges = require('../privileges');
+
+const companiesController = module.exports;
+
+companiesController.list = async function (req, res) {
+    const sort = req.query.sort || 'alpha';
+
+    const [groupData, allowGroupCreation] = await Promise.all([
+        groups.getGroupsBySort(sort, 0, 14),
+        privileges.global.can('group:create', req.uid),
+    ]);
+
+    res.render('companies/list', {
+        groups: groupData,
+        allowGroupCreation: allowGroupCreation,
+        nextStart: 15,
+        title: 'Companies',
+        breadcrumbs: helpers.buildBreadcrumbs([{ text: 'Companies' }]),
+    });
+};
+
+companiesController.details = async function (req, res, next) {
+    const lowercaseSlug = req.params.slug.toLowerCase();
+    if (req.params.slug !== lowercaseSlug) {
+        if (res.locals.isAPI) {
+            req.params.slug = lowercaseSlug;
+        } else {
+            return res.redirect(`${nconf.get('relative_path')}/groups/${lowercaseSlug}`);
+        }
+    }
+    const groupName = await groups.getGroupNameByGroupSlug(req.params.slug);
+    if (!groupName) {
+        return next();
+    }
+    const [exists, isHidden, isAdmin, isGlobalMod] = await Promise.all([
+        groups.exists(groupName),
+        groups.isHidden(groupName),
+        user.isAdministrator(req.uid),
+        user.isGlobalModerator(req.uid),
+    ]);
+    if (!exists) {
+        return next();
+    }
+    if (isHidden && !isAdmin && !isGlobalMod) {
+        const [isMember, isInvited] = await Promise.all([
+            groups.isMember(req.uid, groupName),
+            groups.isInvited(req.uid, groupName),
+        ]);
+        if (!isMember && !isInvited) {
+            return next();
+        }
+    }
+    const [groupData, posts] = await Promise.all([
+        groups.get(groupName, {
+            uid: req.uid,
+            truncateUserList: true,
+            userListCount: 20,
+        }),
+        groups.getLatestMemberPosts(groupName, 10, req.uid),
+    ]);
+    if (!groupData) {
+        return next();
+    }
+    groupData.isOwner = groupData.isOwner || isAdmin || (isGlobalMod && !groupData.system);
+
+    res.render('groups/details', {
+        title: `[[pages:group, ${groupData.displayName}]]`,
+        group: groupData,
+        posts: posts,
+        isAdmin: isAdmin,
+        isGlobalMod: isGlobalMod,
+        allowPrivateGroups: meta.config.allowPrivateGroups,
+        breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[pages:groups]]', url: '/groups' }, { text: groupData.displayName }]),
+    });
+};
+
+companiesController.members = async function (req, res, next) {
+    const page = parseInt(req.query.page, 10) || 1;
+    const usersPerPage = 50;
+    const start = Math.max(0, (page - 1) * usersPerPage);
+    const stop = start + usersPerPage - 1;
+    const groupName = await groups.getGroupNameByGroupSlug(req.params.slug);
+    if (!groupName) {
+        return next();
+    }
+    const [groupData, isAdminOrGlobalMod, isMember, isHidden] = await Promise.all([
+        groups.getGroupData(groupName),
+        user.isAdminOrGlobalMod(req.uid),
+        groups.isMember(req.uid, groupName),
+        groups.isHidden(groupName),
+    ]);
+
+    if (isHidden && !isMember && !isAdminOrGlobalMod) {
+        return next();
+    }
+    const users = await user.getUsersFromSet(`group:${groupName}:members`, req.uid, start, stop);
+
+    const breadcrumbs = helpers.buildBreadcrumbs([
+        { text: '[[pages:groups]]', url: '/groups' },
+        { text: validator.escape(String(groupName)), url: `/groups/${req.params.slug}` },
+        { text: '[[groups:details.members]]' },
+    ]);
+
+    const pageCount = Math.max(1, Math.ceil(groupData.memberCount / usersPerPage));
+    res.render('groups/members', {
+        users: users,
+        pagination: pagination.create(page, pageCount, req.query),
+        breadcrumbs: breadcrumbs,
+    });
+};

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -27,6 +27,7 @@ Controllers.search = require('./search');
 Controllers.user = require('./user');
 Controllers.users = require('./users');
 Controllers.groups = require('./groups');
+Controllers.companies = require('./companies');
 Controllers.accounts = require('./accounts');
 Controllers.authentication = require('./authentication');
 Controllers.api = require('./api');

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -107,6 +107,11 @@ _mounts.groups = (app, name, middleware, controllers) => {
     setupPageRoute(app, `/${name}/:slug/members`, middlewares, controllers.groups.members);
 };
 
+_mounts.companies = (app, name, middleware, controllers) => {
+    const middlewares = [middleware.canViewGroups];
+    setupPageRoute(app, `/companies`, middlewares, controllers.groups.list);
+};
+
 module.exports = async function (app, middleware) {
     const router = express.Router();
     router.render = function (...args) {
@@ -114,7 +119,8 @@ module.exports = async function (app, middleware) {
     };
 
     // Allow plugins/themes to mount some routes elsewhere
-    const remountable = ['admin', 'category', 'topic', 'post', 'users', 'user', 'groups', 'tags', 'career'];
+    const remountable = ['admin', 'category', 'topic', 'post', 'users', 'user',
+        'groups', 'companies', 'tags', 'career'];
     const { mounts } = await plugins.hooks.fire('filter:router.add', {
         mounts: remountable.reduce((memo, mount) => {
             memo[mount] = mount;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -109,7 +109,7 @@ _mounts.groups = (app, name, middleware, controllers) => {
 
 _mounts.companies = (app, name, middleware, controllers) => {
     const middlewares = [middleware.canViewGroups];
-    setupPageRoute(app, `/companies`, middlewares, controllers.groups.list);
+    setupPageRoute(app, `/companies`, middlewares, controllers.companies.list);
 };
 
 module.exports = async function (app, middleware) {
@@ -127,6 +127,7 @@ module.exports = async function (app, middleware) {
             return memo;
         }, {}),
     });
+
     // Guard against plugins sending back missing/extra mounts
     Object.keys(mounts).forEach((mount) => {
         if (!remountable.includes(mount)) {

--- a/themes/nodebb-theme-persona/templates/companies/details.tpl
+++ b/themes/nodebb-theme-persona/templates/companies/details.tpl
@@ -1,0 +1,272 @@
+<div component="groups/container" class="groups details row">
+    <div component="groups/cover" style="background-image: url({group.cover:url}); background-position: {group.cover:position};">
+        <!-- IF group.isOwner -->
+        <div class="controls">
+            <span class="upload"><i class="fa fa-fw fa-4x fa-upload"></i></span>
+            <span class="resize"><i class="fa fa-fw fa-4x fa-arrows"></i></span>
+            <span class="remove"><i class="fa fa-fw fa-4x fa-times"></i></span>
+        </div>
+        <div class="save">[[groups:cover-save]] <i class="fa fa-fw fa-floppy-o"></i></div>
+        <div class="indicator">[[groups:cover-saving]] <i class="fa fa-fw fa-refresh fa-spin"></i></div>
+        <!-- ENDIF group.isOwner -->
+    </div>
+
+    <div class="col-xs-12">
+        <!-- IMPORT partials/breadcrumbs.tpl -->
+    </div>
+
+    <div class="col-lg-4 col-xs-12">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">
+                    <i class="fa fa-list-ul"></i> [[groups:details.title]]
+                    <!-- IF group.private --><span class="label label-info">[[groups:details.private]]</span><!-- ENDIF group.private -->
+                    <!-- IF group.hidden --><span class="label label-info">[[groups:details.hidden]]</span>&nbsp;<!-- ENDIF group.hidden -->
+                </h3>
+            </div>
+            <div class="panel-body">
+                <h1>{group.displayName}</h1>
+                <p>{group.descriptionParsed}</p>
+                <!-- IF isAdmin -->
+                <div class="pull-right">
+                    <a href="{config.relative_path}/admin/manage/groups/{group.nameEncoded}" target="_blank" class="btn btn-info"><i class="fa fa-gear"></i> [[user:edit]]</a>
+                </div>
+                <!-- ENDIF isAdmin -->
+                <!-- IF loggedIn -->
+                <div class="pull-right">
+                    {function.membershipBtn, group}&nbsp;
+                </div>
+                <!-- ENDIF loggedIn -->
+            </div>
+        </div>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title"><i class="fa fa-users"></i> [[groups:details.members]]</h3>
+            </div>
+            <div class="panel-body">
+                <!-- IMPORT partials/groups/memberlist.tpl -->
+            </div>
+        </div>
+        <!-- IF group.isOwner -->
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title clearfix">
+                    <i class="fa fa-clock-o"></i> [[groups:details.pending]]
+                    <!-- IF group.pending.length -->
+                    <div class="btn-group pull-right">
+                        <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+                            [[global:more]] <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu" role="menu">
+                            <li><a href="#" data-ajaxify="false" data-action="acceptAll">[[groups:pending.accept_all]]</a></li>
+                            <li><a href="#" data-ajaxify="false" data-action="rejectAll">[[groups:pending.reject_all]]</a></li>
+                        </ul>
+                    </div>
+                    <!-- ENDIF group.pending.length -->
+                </h3>
+            </div>
+            <div class="panel-body">
+                <table component="groups/pending" class="table table-striped table-hover">
+                    <!-- IF !group.pending.length -->
+                    <div class="alert alert-info">[[groups:pending.none]]</div>
+                    <!-- ENDIF !group.pending.length -->
+                    {{{each group.pending}}}
+                    <tr data-uid="{group.pending.uid}">
+                        <td>
+                            <a href="{config.relative_path}/user/{group.pending.userslug}">{buildAvatar(group.pending, "sm", true)}</a>
+                        </td>
+                        <td class="member-name">
+                            <a href="{config.relative_path}/user/{group.pending.userslug}">{group.pending.username}</a>
+                        </td>
+                        <td>
+                            <div class="btn-group pull-right">
+                                <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+                                    [[global:more]] <span class="caret"></span>
+                                </button>
+                                <ul class="dropdown-menu" role="menu">
+                                    <li><a href="#" data-ajaxify="false" data-action="accept">[[groups:pending.accept]]</a></li>
+                                    <li><a href="#" data-ajaxify="false" data-action="reject">[[groups:pending.reject]]</a></li>
+                                </ul>
+                            </div>
+                        </td>
+                    </tr>
+                    {{{end}}}
+                </table>
+            </div>
+        </div>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title clearfix">
+                    <i class="fa fa-gift"></i> [[groups:details.invited]]
+                </h3>
+            </div>
+            <div class="panel-body">
+                <div class="input-group">
+                    <input class="form-control" type="text" component="groups/members/invite" placeholder="[[groups:invited.search]]"/>
+                    <span class="input-group-addon search-button"><i class="fa fa-search"></i></span>
+                </div>
+
+                <div class="form-group">
+                    <textarea class="form-control" component="groups/members/bulk-invite" placeholder="[[groups:bulk-invite-instructions]]"></textarea>
+                </div>
+
+                <div class="form-group clearfix">
+                    <button class="btn btn-default btn-sm pull-right" component="groups/members/bulk-invite-button">[[groups:bulk-invite]]</button>
+                </div>
+
+                <table component="groups/invited" class="table table-striped table-hover">
+                    <!-- IF !group.invited.length -->
+                    <div class="alert alert-info">[[groups:invited.none]]</div>
+                    <!-- ENDIF !group.invited.length -->
+                    {{{each group.invited}}}
+                    <tr data-uid="{group.invited.uid}">
+                        <td>
+                            <a href="{config.relative_path}/user/{group.invited.userslug}">{buildAvatar(group.invited, "sm", true)}</a>
+                        </td>
+                        <td class="member-name">
+                            <a href="{config.relative_path}/user/{group.invited.userslug}">{group.invited.username}</a>
+                        </td>
+                        <td>
+                            <div class="btn-group pull-right">
+                                <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+                                    [[global:more]] <span class="caret"></span>
+                                </button>
+                                <ul class="dropdown-menu" role="menu">
+                                    <li><a href="#" data-ajaxify="false" data-action="rescindInvite">[[groups:invited.uninvite]]</a></li>
+                                </ul>
+                            </div>
+                        </td>
+                    </tr>
+                    {{{end}}}
+                </table>
+            </div>
+        </div>
+
+        <div class="panel panel-default">
+            <div class="panel-heading pointer" data-toggle="collapse" data-target=".options">
+                <h3 class="panel-title">
+                    <i class="fa fa-caret-down pull-right"></i>
+                    <i class="fa fa-cogs"></i> [[groups:details.owner_options]]
+                </h3>
+            </div>
+
+            <div class="panel-body options collapse">
+                <form component="groups/settings" role="form">
+                    <div class="form-group">
+                        <label for="name">[[groups:details.group_name]]</label>
+                        <input <!-- IF group.system -->readonly<!-- ENDIF group.system --> class="form-control" name="name" id="name" type="text" value="{group.displayName}" />
+                    </div>
+                    <div class="form-group">
+                        <label for="name">[[groups:details.description]]</label>
+                        <textarea class="form-control" name="description" id="description" type="text" maxlength="255">{group.description}</textarea>
+                    </div>
+
+                    <hr />
+                    <div class="form-group">
+                        <label for="memberPostCids">[[groups:details.member-post-cids]]</label>
+                        <div class="row">
+                            <div class="col-md-6">
+                                <input id="memberPostCids" type="text" class="form-control" value="{group.memberPostCids}">
+                            </div>
+                            <div class="col-md-6 member-post-cids-selector">
+                                <!-- IMPORT partials/category-selector.tpl -->
+                            </div>
+                        </div>
+                    </div>
+
+                    <hr />
+
+                    <div class="form-group user-title-option">
+                        <label for="userTitle">[[groups:details.badge_text]]</label>
+                        <input component="groups/userTitleOption" class="form-control" name="userTitle" id="userTitle" type="text" maxlength="40" value="{group.userTitleEscaped}"<!-- IF !group.userTitleEnabled --> disabled<!-- ENDIF !group.userTitleEnabled --> />
+                    </div>
+
+                    <div class="form-group user-title-option">
+                        <label>[[groups:details.badge_preview]]</label><br />
+                        <span class="label<!-- IF !group.userTitleEnabled --> hide<!-- ENDIF !group.userTitleEnabled -->" style="color: {group.textColor}; background-color: {group.labelColor}"><i class="fa<!-- IF group.icon --> {group.icon}<!-- ENDIF group.icon -->"></i> <span class="label-text"><!-- IF group.userTitle -->{group.userTitle}<!-- ELSE -->{group.displayName}<!-- ENDIF group.userTitle --></span></span>
+
+                        <hr/>
+                        <button component="groups/userTitleOption" type="button" class="btn btn-default btn-sm" data-action="icon-select"<!-- IF !group.userTitleEnabled --> disabled<!-- ENDIF !group.userTitleEnabled -->>[[groups:details.change_icon]]</button>
+                        <div>
+                            <label for="labelColor" class="badge-color-label">[[groups:details.change_label_colour]]</label>
+                            <input component="groups/userTitleOption" type="color" name="labelColor" value="<!-- IF group.labelColor -->{group.labelColor}<!-- ENDIF group.labelColor -->" />
+                        </div>
+                        <div>
+                            <label for="color" class="badge-color-label">[[groups:details.change_text_colour]]</label>
+                            <input component="groups/userTitleOption" type="color" name="textColor" value="<!-- IF group.textColor -->{group.textColor}<!-- ENDIF group.textColor -->" />
+                        </div>
+                        <input type="hidden" name="icon" value="<!-- IF group.icon -->{group.icon}<!-- ENDIF group.icon -->" />
+
+                        <div id="icons" class="hidden">
+                            <div class="icon-container">
+                                <div class="row fa-icons">
+                                    <i class="fa fa-doesnt-exist"></i>
+                                    <!-- IMPORT partials/fontawesome.tpl -->
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <hr />
+                    <div class="checkbox">
+                        <label>
+                            <input name="userTitleEnabled" type="checkbox"<!-- IF group.userTitleEnabled --> checked<!-- ENDIF group.userTitleEnabled -->> <strong>[[groups:details.userTitleEnabled]]</strong>
+                        </label>
+                    </div>
+                    <div class="checkbox">
+                        <label>
+                            <input name="private" type="checkbox"<!-- IF group.private --> checked<!-- ENDIF group.private -->> <strong>[[groups:details.private]]</strong>
+                            <!-- IF !allowPrivateGroups -->
+                            <p class="help-block">
+                                [[groups:details.private_system_help]]
+                            </p>
+                            <!-- ENDIF !allowPrivateGroups -->
+                            <p class="help-block">
+                                [[groups:details.private_help]]
+                            </p>
+                        </label>
+                    </div>
+                    <div class="checkbox">
+                        <label>
+                            <input name="disableJoinRequests" type="checkbox"<!-- IF group.disableJoinRequests --> checked<!-- ENDIF group.disableJoinRequests -->> <strong>[[groups:details.disableJoinRequests]]</strong>
+                        </label>
+                    </div>
+                    <div class="checkbox">
+                        <label>
+                            <input name="disableLeave" type="checkbox"{{{if group.disableLeave}}} checked{{{end}}}> <strong>[[groups:details.disableLeave]]</strong>
+                        </label>
+                    </div>
+                    <div class="checkbox">
+                        <label>
+                            <input name="hidden" type="checkbox"<!-- IF group.hidden --> checked<!-- ENDIF group.hidden -->> <strong>[[groups:details.hidden]]</strong>
+                            <p class="help-block">
+                                [[groups:details.hidden_help]]
+                            </p>
+                        </label>
+                    </div>
+
+                    <button class="btn btn-link btn-xs pull-right" type="button" data-action="delete">[[groups:details.delete_group]]</button>
+                    <button class="btn btn-primary" type="button" data-action="update">[[global:save_changes]]</button>
+                </form>
+            </div>
+        </div>
+        <!-- ENDIF group.isOwner -->
+        <div data-widget-area="left">
+            {{{each widgets.left}}}
+            {{widgets.left.html}}
+            {{{end}}}
+        </div>
+    </div>
+    <div class="col-lg-8 col-xs-12">
+        <div class="col-lg-11">
+            <!-- IF !posts.length -->
+            <div class="alert alert-info">[[groups:details.has_no_posts]]</div>
+            <!-- ENDIF !posts.length -->
+            <!-- IMPORT partials/posts_list.tpl -->
+        </div>
+        <div data-widget-area="right">
+            {{{each widgets.right}}}
+            {{widgets.right.html}}
+            {{{end}}}
+        </div>
+    </div>
+</div>

--- a/themes/nodebb-theme-persona/templates/companies/list.tpl
+++ b/themes/nodebb-theme-persona/templates/companies/list.tpl
@@ -1,0 +1,46 @@
+<!-- IMPORT partials/breadcrumbs.tpl -->
+<div data-widget-area="header">
+    {{{each widgets.header}}}
+    {{widgets.header.html}}
+    {{{end}}}
+</div>
+<div class="groups list">
+    <div class="row">
+        <div class="col-lg-4">
+            <!-- IF allowGroupCreation -->
+            <button class="btn btn-primary" data-action="new"><i class="fa fa-plus"></i> Create New Company</button>
+            <!-- ENDIF allowGroupCreation -->
+        </div>
+        <div class="col-lg-8">
+            <div class="row">
+                <div class="col-xs-5 col-md-3 text-left pull-right">
+                    <select class="form-control" id="search-sort">
+                        <option value="alpha">[[groups:details.group_name]]</option>
+                        <option value="count">[[groups:details.member_count]]</option>
+                        <option value="date">[[groups:details.creation_date]]</option>
+                    </select>
+                </div>
+                <div class="col-xs-7 col-md-5 text-left pull-right">
+                    <div class="input-group">
+                        <input type="text" class="form-control" placeholder="[[global:search]]" name="query" value="" id="search-text">
+                        <span id="search-button" class="input-group-addon search-button"><i class="fa fa-search"></i></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <hr />
+
+    <div component="groups/container" class="row" id="groups-list" data-nextstart={nextStart}>
+        <!-- IF groups.length -->
+        <!-- IMPORT partials/groups/list.tpl -->
+        <!-- ELSE -->
+        <div class="col-xs-12">
+            <div class="alert alert-warning">
+            [[groups:no_groups_found]]
+            </div>
+        </div>
+        <!-- ENDIF groups.length -->
+    </div>
+</div>

--- a/themes/nodebb-theme-persona/templates/companies/list.tpl
+++ b/themes/nodebb-theme-persona/templates/companies/list.tpl
@@ -8,7 +8,9 @@
     <div class="row">
         <div class="col-lg-4">
             <!-- IF allowGroupCreation -->
+            {{{ if (accounttype != "student") }}}
             <button class="btn btn-primary" data-action="new"><i class="fa fa-plus"></i> Create New Company</button>
+            {{{ end }}}
             <!-- ENDIF allowGroupCreation -->
         </div>
         <div class="col-lg-8">

--- a/themes/nodebb-theme-persona/templates/companies/members.tpl
+++ b/themes/nodebb-theme-persona/templates/companies/members.tpl
@@ -1,0 +1,9 @@
+<!-- IMPORT partials/breadcrumbs.tpl -->
+<div class="users">
+
+    <ul id="users-container" class="users-container">
+        <!-- IMPORT partials/users_list.tpl -->
+    </ul>
+
+    <!-- IMPORT partials/paginator.tpl -->
+</div>

--- a/themes/nodebb-theme-persona/templates/partials/menu.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/menu.tpl
@@ -137,6 +137,11 @@
                             <li role="presentation" class="divider"></li>
                             <li class="dropdown-header">[[pages:moderator-tools]]</li>
                             <li>
+                                <a href="{relative_path}/companies">
+                                    <i class="fa fa-fw fa-list-alt"></i> <span>Companies</span>
+                                </a>
+                            </li>
+                            <li>
                                 <a href="{relative_path}/flags">
                                     <i class="fa fa-fw fa-flag"></i> <span>[[pages:flagged-content]]</span>
                                 </a>

--- a/themes/nodebb-theme-persona/templates/partials/menu.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/menu.tpl
@@ -133,14 +133,15 @@
                                     <i class="fa fa-fw fa-gear"></i> <span>[[user:settings]]</span>
                                 </a>
                             </li>
-                            {{{ if showModMenu }}}
                             <li role="presentation" class="divider"></li>
-                            <li class="dropdown-header">[[pages:moderator-tools]]</li>
                             <li>
                                 <a href="{relative_path}/companies">
                                     <i class="fa fa-fw fa-list-alt"></i> <span>Companies</span>
                                 </a>
                             </li>
+                            {{{ if showModMenu }}}
+                            <li role="presentation" class="divider"></li>
+                            <li class="dropdown-header">[[pages:moderator-tools]]</li>
                             <li>
                                 <a href="{relative_path}/flags">
                                     <i class="fa fa-fw fa-flag"></i> <span>[[pages:flagged-content]]</span>


### PR DESCRIPTION
Create entry point to company page from dropdown, mounted to the company route, but currently reading from groups data

- Updated read.yaml file for new company page
- Added companies controller in preparation for future backend edits (i.e. get company data from database and render company information)
- Mounted companies to its own "/companies" route
- Blocked students from creating new companies

Future work:
- Stores companies to database, allow creation and storage of new companies
- View companies data from companies page

Resolves #14 
