### PR TITLE
Recruiter Job Postings

### DIFF
--- a/install/data/categories.json
+++ b/install/data/categories.json
@@ -34,5 +34,14 @@
         "color": "#ffffff",
         "icon" : "fa-question",
         "order": 3
+    },
+    {
+        "name": "Job Postings",
+        "description": "Check job postings from recruiters",
+        "descriptionParsed": "<p>Check job postings from recruiters</p>\n",
+        "bgColor": "#dbb125",
+        "color": "#ffffff",
+        "icon": "fa-briefcase",
+        "order": 5
     }
 ]

--- a/install/data/categories.json
+++ b/install/data/categories.json
@@ -34,14 +34,5 @@
         "color": "#ffffff",
         "icon" : "fa-question",
         "order": 3
-    },
-    {
-        "name": "Job Postings",
-        "description": "Check job postings from recruiters",
-        "descriptionParsed": "<p>Check job postings from recruiters</p>\n",
-        "bgColor": "#dbb125",
-        "color": "#ffffff",
-        "icon": "fa-briefcase",
-        "order": 5
     }
 ]

--- a/install/package.json
+++ b/install/package.json
@@ -152,6 +152,7 @@
         "@types/async": "^3.2.16",
         "@types/express": "^4.17.15",
         "@types/lodash": "^4.14.191",
+        "@types/mocha": "^10.0.6",
         "@types/nconf": "^0.10.3",
         "@types/semver": "^7.3.13",
         "@types/validator": "^13.7.0",

--- a/src/install.js
+++ b/src/install.js
@@ -420,6 +420,24 @@ async function createGlobalModeratorsGroup() {
     await groups.show('Global Moderators');
 }
 
+async function createRecruitersGroup() {
+    const groups = require('./groups');
+    const exists = await groups.exists('Recruiters');
+    if (exists) {
+        winston.info('Recruiters group found, skipping creation!');
+    } else {
+        await groups.create({
+            name: 'Recruiters',
+            userTitle: 'Recruiters',
+            description: 'Recruiters from companies',
+            hidden: 0,
+            private: 1,
+            disableJoinRequests: 1,
+        });
+    }
+    await groups.show('Recruiters');
+}
+
 async function giveGlobalPrivileges() {
     const privileges = require('./privileges');
     const defaultPrivileges = [
@@ -574,6 +592,7 @@ install.setup = async function () {
         await createDefaultUserGroups();
         const adminInfo = await createAdministrator();
         await createGlobalModeratorsGroup();
+        await createRecruitersGroup();
         await giveGlobalPrivileges();
         await createMenuItems();
         await createWelcomePost();

--- a/src/install.js
+++ b/src/install.js
@@ -471,6 +471,37 @@ async function createCategories() {
         // eslint-disable-next-line no-await-in-loop
         await Categories.create(categoryData);
     }
+
+    await createJobPostingsCategory();
+}
+
+async function createJobPostingsCategory() {
+    const Categories = require('./categories');
+    const privileges = require('./privileges');
+
+    const data =
+    {
+        "name": "Job Postings",
+        "description": "Check job postings from recruiters",
+        "descriptionParsed": "<p>Check job postings from recruiters</p>\n",
+        "bgColor": "#dbb125",
+        "color": "#ffffff",
+        "icon": "fa-briefcase",
+        "order": 5
+    }
+    const jobPostings = await Categories.create(data);
+
+    const postingPrivileges = [
+        'groups:topics:create',
+        'groups:posts:edit',
+        'groups:posts:delete',
+        'groups:topics:delete',
+    ];
+
+    await Promise.all([
+        privileges.categories.rescind(postingPrivileges, jobPostings.cid, 'registered-users'),
+        privileges.categories.give(postingPrivileges, jobPostings.cid, 'Recruiters')
+    ]);
 }
 
 async function createMenuItems() {
@@ -588,12 +619,12 @@ install.setup = async function () {
         await setupConfig();
         await setupDefaultConfigs();
         await enableDefaultTheme();
-        await createCategories();
         await createDefaultUserGroups();
         const adminInfo = await createAdministrator();
         await createGlobalModeratorsGroup();
-        await createRecruitersGroup();
         await giveGlobalPrivileges();
+        await createRecruitersGroup();
+        await createCategories();
         await createMenuItems();
         await createWelcomePost();
         await enableDefaultPlugins();

--- a/src/install.js
+++ b/src/install.js
@@ -481,14 +481,14 @@ async function createJobPostingsCategory() {
 
     const data =
     {
-        "name": "Job Postings",
-        "description": "Check job postings from recruiters",
-        "descriptionParsed": "<p>Check job postings from recruiters</p>\n",
-        "bgColor": "#dbb125",
-        "color": "#ffffff",
-        "icon": "fa-briefcase",
-        "order": 5
-    }
+        name: 'Job Postings',
+        description: 'Check job postings from recruiters',
+        descriptionParsed: '<p>Check job postings from recruiters</p>\n',
+        bgColor: '#dbb125',
+        color: '#ffffff',
+        icon: 'fa-briefcase',
+        order: 5,
+    };
     const jobPostings = await Categories.create(data);
 
     const postingPrivileges = [
@@ -500,7 +500,7 @@ async function createJobPostingsCategory() {
 
     await Promise.all([
         privileges.categories.rescind(postingPrivileges, jobPostings.cid, 'registered-users'),
-        privileges.categories.give(postingPrivileges, jobPostings.cid, 'Recruiters')
+        privileges.categories.give(postingPrivileges, jobPostings.cid, 'Recruiters'),
     ]);
 }
 

--- a/src/user/create.js
+++ b/src/user/create.js
@@ -108,7 +108,7 @@ module.exports = function (User) {
             User.updateDigestSetting(userData.uid, meta.config.dailyDigestFreq),
         ]);
 
-        if (userData.accounttype == 'recruiter') {
+        if (userData.accounttype === 'recruiter') {
             await groups.join('Recruiters', userData.uid);
         }
 

--- a/src/user/create.js
+++ b/src/user/create.js
@@ -108,6 +108,10 @@ module.exports = function (User) {
             User.updateDigestSetting(userData.uid, meta.config.dailyDigestFreq),
         ]);
 
+        if (userData.accounttype == 'recruiter') {
+            await groups.join('Recruiters', userData.uid);
+        }
+
         if (userData.email && isFirstUser) {
             await User.email.confirmByUid(userData.uid);
         }

--- a/test/recruiters.js
+++ b/test/recruiters.js
@@ -1,0 +1,140 @@
+'use strict';
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+const assert = require('assert');
+const async = require('async');
+const fs = require('fs');
+const path = require('path');
+const nconf = require('nconf');
+const db = require('./mocks/databasemock');
+const helpers = require('./helpers');
+const Groups = require('../src/groups');
+const User = require('../src/user');
+const meta = require('../src/meta');
+const navigation = require('../src/navigation/admin');
+const Categories = require('../src/categories');
+const privileges = require('../src/privileges');
+const install = require('../src/install');
+describe('Groups', () => {
+    let adminUid;
+    let studentUid;
+    let recruiterUid;
+    let jobPostingsCategory;
+    before(() => __awaiter(void 0, void 0, void 0, function* () {
+        const navData = require('../install/data/navigation.json');
+        yield navigation.save(navData);
+        yield Groups.create({
+            name: 'Recruiters',
+            userTitle: 'Recruiters',
+            description: 'Company recruiters',
+            hidden: 0,
+            private: 1,
+            disableJoinRequests: 1,
+        });
+        studentUid = yield User.create({
+            username: 'student',
+            email: 'student@test.com',
+        });
+        adminUid = yield User.create({
+            username: 'admin',
+            email: 'admin@test.com',
+        });
+        yield Groups.join('administrators', adminUid);
+        recruiterUid = yield User.create({
+            username: 'recruiter',
+            email: 'recruiter@test.com',
+            accounttype: 'recruiter'
+        });
+    }));
+    it('Recruiters group should have one member', (done) => {
+        Groups.get('Recruiters', {}, (err, groupObj) => {
+            assert.ifError(err);
+            assert.strictEqual(groupObj.name, 'Recruiters');
+            assert.strictEqual(groupObj.memberCount, 1);
+            done();
+        });
+    });
+    it('recruiter user should automatically be in the Recruiters group', (done) => {
+        Groups.isMember(recruiterUid, 'Recruiters', (err, isMember) => {
+            assert.ifError(err);
+            assert.strictEqual(isMember, true);
+            done();
+        });
+    });
+    it('student user should not be in the Recruiters group', (done) => {
+        Groups.isMember(studentUid, 'Recruiters', (err, isMember) => {
+            assert.ifError(err);
+            assert.strictEqual(isMember, false);
+            done();
+        });
+    });
+    it('admin user should not be in the Recruiters group', (done) => {
+        Groups.isMember(adminUid, 'Recruiters', (err, isMember) => {
+            assert.ifError(err);
+            assert.strictEqual(isMember, false);
+            done();
+        });
+    });
+    it('should create a new job postings category', (done) => {
+        Categories.create({
+            name: 'Job Postings',
+            description: 'Check job postings from recruiters',
+            icon: 'fa-check',
+            blockclass: 'category-blue',
+            order: '5',
+        }, (err, category) => {
+            assert.ifError(err);
+            jobPostingsCategory = category;
+            done();
+        });
+    });
+    it('should set privileges for job postings', () => __awaiter(void 0, void 0, void 0, function* () {
+        const postingPrivileges = [
+            'groups:topics:create',
+            'groups:posts:edit',
+            'groups:posts:delete',
+            'groups:topics:delete',
+        ];
+        yield Promise.all([
+            privileges.categories.rescind(postingPrivileges, jobPostingsCategory.cid, 'registered-users'),
+            privileges.categories.give(postingPrivileges, jobPostingsCategory.cid, 'Recruiters')
+        ]);
+    }));
+    it('recruiters should have posting privileges on job postings category', () => __awaiter(void 0, void 0, void 0, function* () {
+        const canCreateTopics = yield privileges.categories.can('topics:create', jobPostingsCategory.cid, recruiterUid);
+        assert(canCreateTopics);
+        const canDeleteTopics = yield privileges.categories.can('topics:delete', jobPostingsCategory.cid, recruiterUid);
+        assert(canDeleteTopics);
+        const canEditPosts = yield privileges.categories.can('posts:edit', jobPostingsCategory.cid, recruiterUid);
+        assert(canEditPosts);
+        const canDeletePosts = yield privileges.categories.can('posts:delete', jobPostingsCategory.cid, recruiterUid);
+        assert(canDeletePosts);
+    }));
+    it('students should not have posting privileges on job postings category', () => __awaiter(void 0, void 0, void 0, function* () {
+        const canCreateTopics = yield privileges.categories.can('topics:create', jobPostingsCategory.cid, studentUid);
+        assert(!canCreateTopics);
+        const canDeleteTopics = yield privileges.categories.can('topics:delete', jobPostingsCategory.cid, studentUid);
+        assert(!canDeleteTopics);
+        const canEditPosts = yield privileges.categories.can('posts:edit', jobPostingsCategory.cid, studentUid);
+        assert(!canEditPosts);
+        const canDeletePosts = yield privileges.categories.can('posts:delete', jobPostingsCategory.cid, studentUid);
+        assert(!canDeletePosts);
+    }));
+    it('admins should have posting privileges on job postings category', () => __awaiter(void 0, void 0, void 0, function* () {
+        const canCreateTopics = yield privileges.categories.can('topics:create', jobPostingsCategory.cid, adminUid);
+        assert(canCreateTopics);
+        const canDeleteTopics = yield privileges.categories.can('topics:delete', jobPostingsCategory.cid, adminUid);
+        assert(canDeleteTopics);
+        const canEditPosts = yield privileges.categories.can('posts:edit', jobPostingsCategory.cid, adminUid);
+        assert(canEditPosts);
+        const canDeletePosts = yield privileges.categories.can('posts:delete', jobPostingsCategory.cid, adminUid);
+        assert(canDeletePosts);
+    }));
+});

--- a/test/recruiters.js
+++ b/test/recruiters.js
@@ -22,7 +22,7 @@ describe('Groups', () => {
     before(() => __awaiter(void 0, void 0, void 0, function* () {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield Groups.create({
+        Groups.create({
             name: 'Recruiters',
             userTitle: 'Recruiters',
             description: 'Company recruiters',
@@ -53,23 +53,35 @@ describe('Groups', () => {
             accounttype: 'recruiter',
         }));
     }));
-    it('Recruiters group should have one member', (done) => __awaiter(void 0, void 0, void 0, function* () {
-        yield Groups.get('Recruiters', {}, (err, groupObj) => {
+    it('Recruiters group should have one member', (done) => {
+        Groups.get('Recruiters', {}, (err, groupObj) => {
             assert.ifError(err);
             assert.strictEqual(groupObj.name, 'Recruiters');
             assert.strictEqual(groupObj.memberCount, 1);
             done();
-        });
-    }));
-    it('recruiter user should automatically be in the Recruiters group', (done) => __awaiter(void 0, void 0, void 0, function* () {
+        }).catch(() => 'obligatory catch');
+    });
+    // it('with no options, should show group information', (done) => {
+    //     Groups.get('Test', {}, (err, groupObj) => {
+    //         assert.ifError(err);
+    //         assert.equal(typeof groupObj, 'object');
+    //         assert(Array.isArray(groupObj.members));
+    //         assert.strictEqual(groupObj.name, 'Test');
+    //         assert.strictEqual(groupObj.description, 'Foobar!');
+    //         assert.strictEqual(groupObj.memberCount, 1);
+    //         assert.equal(typeof groupObj.members[0], 'object');
+    //         done();
+    //     });
+    // });
+    it('recruiter user should automatically be in the Recruiters group', (done) => {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield Groups.isMember(recruiterUid, 'Recruiters', (err, isMember) => {
+        Groups.isMember(recruiterUid, 'Recruiters', (err, isMember) => {
             assert.ifError(err);
             assert.strictEqual(isMember, true);
             done();
         });
-    }));
+    });
     it('student user should not be in the Recruiters group', (done) => {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call

--- a/test/recruiters.js
+++ b/test/recruiters.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -8,28 +8,20 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const assert = require('assert');
-const async = require('async');
-const fs = require('fs');
-const path = require('path');
-const nconf = require('nconf');
-const db = require('./mocks/databasemock');
-const helpers = require('./helpers');
-const Groups = require('../src/groups');
-const User = require('../src/user');
-const meta = require('../src/meta');
-const navigation = require('../src/navigation/admin');
-const Categories = require('../src/categories');
-const privileges = require('../src/privileges');
-const install = require('../src/install');
+Object.defineProperty(exports, "__esModule", { value: true });
+const assert = require("assert");
+const Groups = require("../src/groups");
+const User = require("../src/user");
+const Categories = require("../src/categories");
+const privileges = require("../src/privileges");
 describe('Groups', () => {
     let adminUid;
     let studentUid;
     let recruiterUid;
     let jobPostingsCategory;
     before(() => __awaiter(void 0, void 0, void 0, function* () {
-        const navData = require('../install/data/navigation.json');
-        yield navigation.save(navData);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         yield Groups.create({
             name: 'Recruiters',
             userTitle: 'Recruiters',
@@ -38,37 +30,49 @@ describe('Groups', () => {
             private: 1,
             disableJoinRequests: 1,
         });
-        studentUid = yield User.create({
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        studentUid = (yield User.create({
             username: 'student',
             email: 'student@test.com',
-        });
-        adminUid = yield User.create({
+        }));
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        adminUid = (yield User.create({
             username: 'admin',
             email: 'admin@test.com',
-        });
+        }));
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         yield Groups.join('administrators', adminUid);
-        recruiterUid = yield User.create({
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        recruiterUid = (yield User.create({
             username: 'recruiter',
             email: 'recruiter@test.com',
-            accounttype: 'recruiter'
-        });
+            accounttype: 'recruiter',
+        }));
     }));
-    it('Recruiters group should have one member', (done) => {
-        Groups.get('Recruiters', {}, (err, groupObj) => {
+    it('Recruiters group should have one member', (done) => __awaiter(void 0, void 0, void 0, function* () {
+        yield Groups.get('Recruiters', {}, (err, groupObj) => {
             assert.ifError(err);
             assert.strictEqual(groupObj.name, 'Recruiters');
             assert.strictEqual(groupObj.memberCount, 1);
             done();
         });
-    });
-    it('recruiter user should automatically be in the Recruiters group', (done) => {
-        Groups.isMember(recruiterUid, 'Recruiters', (err, isMember) => {
+    }));
+    it('recruiter user should automatically be in the Recruiters group', (done) => __awaiter(void 0, void 0, void 0, function* () {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        yield Groups.isMember(recruiterUid, 'Recruiters', (err, isMember) => {
             assert.ifError(err);
             assert.strictEqual(isMember, true);
             done();
         });
-    });
+    }));
     it('student user should not be in the Recruiters group', (done) => {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         Groups.isMember(studentUid, 'Recruiters', (err, isMember) => {
             assert.ifError(err);
             assert.strictEqual(isMember, false);
@@ -76,6 +80,8 @@ describe('Groups', () => {
         });
     });
     it('admin user should not be in the Recruiters group', (done) => {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         Groups.isMember(adminUid, 'Recruiters', (err, isMember) => {
             assert.ifError(err);
             assert.strictEqual(isMember, false);
@@ -83,6 +89,8 @@ describe('Groups', () => {
         });
     });
     it('should create a new job postings category', (done) => {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         Categories.create({
             name: 'Job Postings',
             description: 'Check job postings from recruiters',
@@ -104,7 +112,7 @@ describe('Groups', () => {
         ];
         yield Promise.all([
             privileges.categories.rescind(postingPrivileges, jobPostingsCategory.cid, 'registered-users'),
-            privileges.categories.give(postingPrivileges, jobPostingsCategory.cid, 'Recruiters')
+            privileges.categories.give(postingPrivileges, jobPostingsCategory.cid, 'Recruiters'),
         ]);
     }));
     it('recruiters should have posting privileges on job postings category', () => __awaiter(void 0, void 0, void 0, function* () {

--- a/test/recruiters.ts
+++ b/test/recruiters.ts
@@ -1,0 +1,171 @@
+'use strict';
+
+const assert = require('assert');
+const async = require('async');
+const fs = require('fs');
+const path = require('path');
+const nconf = require('nconf');
+
+const db = require('./mocks/databasemock');
+const helpers = require('./helpers');
+const Groups = require('../src/groups');
+const User = require('../src/user');
+const meta = require('../src/meta');
+const navigation = require('../src/navigation/admin');
+const Categories = require('../src/categories');
+const privileges = require('../src/privileges');
+const install = require('../src/install');
+
+describe('Groups', () => {
+	let adminUid;
+	let studentUid;
+	let recruiterUid;
+	let jobPostingsCategory;
+	before(async () => {
+		const navData = require('../install/data/navigation.json');
+		await navigation.save(navData);
+
+		await Groups.create({
+			name: 'Recruiters',
+			userTitle: 'Recruiters',
+			description: 'Company recruiters',
+			hidden: 0,
+			private: 1,
+			disableJoinRequests: 1,
+		});
+
+		studentUid = await User.create({
+			username: 'student',
+			email: 'student@test.com',
+		});
+
+		adminUid = await User.create({
+			username: 'admin',
+			email: 'admin@test.com',
+		});
+		await Groups.join('administrators', adminUid);
+
+		recruiterUid = await User.create({
+			username: 'recruiter',
+			email: 'recruiter@test.com',
+			accounttype: 'recruiter'
+		});
+	});
+
+	it('Recruiters group should have one member', (done) => {
+		Groups.get('Recruiters', {}, (err, groupObj) => {
+			assert.ifError(err);
+			assert.strictEqual(groupObj.name, 'Recruiters');
+			assert.strictEqual(groupObj.memberCount, 1);
+
+			done();
+		});
+	});
+
+	it('recruiter user should automatically be in the Recruiters group', (done) => {
+		Groups.isMember(recruiterUid, 'Recruiters', (err, isMember) => {
+			assert.ifError(err);
+			assert.strictEqual(isMember, true);
+			done();
+		});
+	});
+
+	it('student user should not be in the Recruiters group', (done) => {
+		Groups.isMember(studentUid, 'Recruiters', (err, isMember) => {
+			assert.ifError(err);
+			assert.strictEqual(isMember, false);
+			done();
+		});
+	});
+
+	it('admin user should not be in the Recruiters group', (done) => {
+		Groups.isMember(adminUid, 'Recruiters', (err, isMember) => {
+			assert.ifError(err);
+			assert.strictEqual(isMember, false);
+			done();
+		});
+	});
+
+	it('should create a new job postings category', (done) => {
+		Categories.create({
+			name: 'Job Postings',
+			description: 'Check job postings from recruiters',
+			icon: 'fa-check',
+			blockclass: 'category-blue',
+			order: '5',
+		}, (err, category) => {
+			assert.ifError(err);
+
+			jobPostingsCategory = category;
+			done();
+		});
+	});
+
+	it('should set privileges for job postings', async () => {
+		const postingPrivileges = [
+			'groups:topics:create',
+			'groups:posts:edit',
+			'groups:posts:delete',
+			'groups:topics:delete',
+		];
+
+		await Promise.all([
+			privileges.categories.rescind(postingPrivileges, jobPostingsCategory.cid, 'registered-users'),
+			privileges.categories.give(postingPrivileges, jobPostingsCategory.cid, 'Recruiters')
+		]);
+	});
+
+	it('recruiters should have posting privileges on job postings category', async () => {
+		const canCreateTopics = await privileges.categories.can('topics:create',
+			jobPostingsCategory.cid, recruiterUid);
+		assert(canCreateTopics);
+
+		const canDeleteTopics = await privileges.categories.can('topics:delete', 
+			jobPostingsCategory.cid, recruiterUid);
+		assert(canDeleteTopics);
+
+		const canEditPosts = await privileges.categories.can('posts:edit',
+			jobPostingsCategory.cid, recruiterUid);
+		assert(canEditPosts);
+
+		const canDeletePosts = await privileges.categories.can('posts:delete',
+			jobPostingsCategory.cid, recruiterUid);
+		assert(canDeletePosts);
+	});
+
+	it('students should not have posting privileges on job postings category', async () => {
+		const canCreateTopics = await privileges.categories.can('topics:create',
+			jobPostingsCategory.cid, studentUid);
+		assert(!canCreateTopics);
+
+		const canDeleteTopics = await privileges.categories.can('topics:delete',
+			jobPostingsCategory.cid, studentUid);
+		assert(!canDeleteTopics);
+
+		const canEditPosts = await privileges.categories.can('posts:edit',
+			jobPostingsCategory.cid, studentUid);
+		assert(!canEditPosts);
+
+		const canDeletePosts = await privileges.categories.can('posts:delete',
+			jobPostingsCategory.cid, studentUid);
+		assert(!canDeletePosts);
+	});
+
+	it('admins should have posting privileges on job postings category', async () => {
+		const canCreateTopics = await privileges.categories.can('topics:create',
+			jobPostingsCategory.cid, adminUid);
+		assert(canCreateTopics);
+
+		const canDeleteTopics = await privileges.categories.can('topics:delete',
+			jobPostingsCategory.cid, adminUid);
+		assert(canDeleteTopics);
+
+		const canEditPosts = await privileges.categories.can('posts:edit',
+			jobPostingsCategory.cid, adminUid);
+		assert(canEditPosts);
+
+		const canDeletePosts = await privileges.categories.can('posts:delete',
+			jobPostingsCategory.cid, adminUid);
+		assert(canDeletePosts);
+	});
+})

--- a/test/recruiters.ts
+++ b/test/recruiters.ts
@@ -21,7 +21,7 @@ describe('Groups', () => {
     before(async () => {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        await Groups.create({
+        Groups.create({
             name: 'Recruiters',
             userTitle: 'Recruiters',
             description: 'Company recruiters',
@@ -56,20 +56,20 @@ describe('Groups', () => {
         }) as number;
     });
 
-    it('Recruiters group should have one member', async (done) => {
-        await Groups.get('Recruiters', {}, (err, groupObj: GroupTest) => {
+    it('Recruiters group should have one member', (done) => {
+        Groups.get('Recruiters', {}, (err, groupObj : GroupTest) => {
             assert.ifError(err);
             assert.strictEqual(groupObj.name, 'Recruiters');
             assert.strictEqual(groupObj.memberCount, 1);
 
             done();
-        });
+        }).catch(() => 'obligatory catch');
     });
 
-    it('recruiter user should automatically be in the Recruiters group', async (done) => {
+    it('recruiter user should automatically be in the Recruiters group', (done) => {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        await Groups.isMember(recruiterUid, 'Recruiters', (err, isMember) => {
+        Groups.isMember(recruiterUid, 'Recruiters', (err, isMember) => {
             assert.ifError(err);
             assert.strictEqual(isMember, true);
             done();

--- a/test/recruiters.ts
+++ b/test/recruiters.ts
@@ -1,171 +1,220 @@
-'use strict';
+import assert = require('assert');
+import Groups = require('../src/groups');
+import User = require('../src/user');
+import Categories = require('../src/categories');
+import privileges = require('../src/privileges');
 
-const assert = require('assert');
-const async = require('async');
-const fs = require('fs');
-const path = require('path');
-const nconf = require('nconf');
+type CategoryTest = {
+    cid: number,
+};
 
-const db = require('./mocks/databasemock');
-const helpers = require('./helpers');
-const Groups = require('../src/groups');
-const User = require('../src/user');
-const meta = require('../src/meta');
-const navigation = require('../src/navigation/admin');
-const Categories = require('../src/categories');
-const privileges = require('../src/privileges');
-const install = require('../src/install');
+type GroupTest = {
+    name: string,
+    memberCount: number,
+};
 
 describe('Groups', () => {
-	let adminUid;
-	let studentUid;
-	let recruiterUid;
-	let jobPostingsCategory;
-	before(async () => {
-		const navData = require('../install/data/navigation.json');
-		await navigation.save(navData);
+    let adminUid: number;
+    let studentUid: number;
+    let recruiterUid: number;
+    let jobPostingsCategory: CategoryTest;
+    before(async () => {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await Groups.create({
+            name: 'Recruiters',
+            userTitle: 'Recruiters',
+            description: 'Company recruiters',
+            hidden: 0,
+            private: 1,
+            disableJoinRequests: 1,
+        });
 
-		await Groups.create({
-			name: 'Recruiters',
-			userTitle: 'Recruiters',
-			description: 'Company recruiters',
-			hidden: 0,
-			private: 1,
-			disableJoinRequests: 1,
-		});
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        studentUid = await User.create({
+            username: 'student',
+            email: 'student@test.com',
+        }) as number;
 
-		studentUid = await User.create({
-			username: 'student',
-			email: 'student@test.com',
-		});
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        adminUid = await User.create({
+            username: 'admin',
+            email: 'admin@test.com',
+        }) as number;
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await Groups.join('administrators', adminUid);
 
-		adminUid = await User.create({
-			username: 'admin',
-			email: 'admin@test.com',
-		});
-		await Groups.join('administrators', adminUid);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        recruiterUid = await User.create({
+            username: 'recruiter',
+            email: 'recruiter@test.com',
+            accounttype: 'recruiter',
+        }) as number;
+    });
 
-		recruiterUid = await User.create({
-			username: 'recruiter',
-			email: 'recruiter@test.com',
-			accounttype: 'recruiter'
-		});
-	});
+    it('Recruiters group should have one member', async (done) => {
+        await Groups.get('Recruiters', {}, (err, groupObj: GroupTest) => {
+            assert.ifError(err);
+            assert.strictEqual(groupObj.name, 'Recruiters');
+            assert.strictEqual(groupObj.memberCount, 1);
 
-	it('Recruiters group should have one member', (done) => {
-		Groups.get('Recruiters', {}, (err, groupObj) => {
-			assert.ifError(err);
-			assert.strictEqual(groupObj.name, 'Recruiters');
-			assert.strictEqual(groupObj.memberCount, 1);
+            done();
+        });
+    });
 
-			done();
-		});
-	});
+    it('recruiter user should automatically be in the Recruiters group', async (done) => {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await Groups.isMember(recruiterUid, 'Recruiters', (err, isMember) => {
+            assert.ifError(err);
+            assert.strictEqual(isMember, true);
+            done();
+        });
+    });
 
-	it('recruiter user should automatically be in the Recruiters group', (done) => {
-		Groups.isMember(recruiterUid, 'Recruiters', (err, isMember) => {
-			assert.ifError(err);
-			assert.strictEqual(isMember, true);
-			done();
-		});
-	});
+    it('student user should not be in the Recruiters group', (done) => {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        Groups.isMember(studentUid, 'Recruiters', (err, isMember) => {
+            assert.ifError(err);
+            assert.strictEqual(isMember, false);
+            done();
+        });
+    });
 
-	it('student user should not be in the Recruiters group', (done) => {
-		Groups.isMember(studentUid, 'Recruiters', (err, isMember) => {
-			assert.ifError(err);
-			assert.strictEqual(isMember, false);
-			done();
-		});
-	});
+    it('admin user should not be in the Recruiters group', (done) => {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        Groups.isMember(adminUid, 'Recruiters', (err, isMember) => {
+            assert.ifError(err);
+            assert.strictEqual(isMember, false);
+            done();
+        });
+    });
 
-	it('admin user should not be in the Recruiters group', (done) => {
-		Groups.isMember(adminUid, 'Recruiters', (err, isMember) => {
-			assert.ifError(err);
-			assert.strictEqual(isMember, false);
-			done();
-		});
-	});
+    it('should create a new job postings category', (done) => {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        Categories.create({
+            name: 'Job Postings',
+            description: 'Check job postings from recruiters',
+            icon: 'fa-check',
+            blockclass: 'category-blue',
+            order: '5',
+        }, (err, category: CategoryTest) => {
+            assert.ifError(err);
 
-	it('should create a new job postings category', (done) => {
-		Categories.create({
-			name: 'Job Postings',
-			description: 'Check job postings from recruiters',
-			icon: 'fa-check',
-			blockclass: 'category-blue',
-			order: '5',
-		}, (err, category) => {
-			assert.ifError(err);
+            jobPostingsCategory = category;
+            done();
+        });
+    });
 
-			jobPostingsCategory = category;
-			done();
-		});
-	});
+    it('should set privileges for job postings', async () => {
+        const postingPrivileges = [
+            'groups:topics:create',
+            'groups:posts:edit',
+            'groups:posts:delete',
+            'groups:topics:delete',
+        ];
 
-	it('should set privileges for job postings', async () => {
-		const postingPrivileges = [
-			'groups:topics:create',
-			'groups:posts:edit',
-			'groups:posts:delete',
-			'groups:topics:delete',
-		];
+        await Promise.all([
+            privileges.categories.rescind(postingPrivileges, jobPostingsCategory.cid, 'registered-users'),
+            privileges.categories.give(postingPrivileges, jobPostingsCategory.cid, 'Recruiters'),
+        ]);
+    });
 
-		await Promise.all([
-			privileges.categories.rescind(postingPrivileges, jobPostingsCategory.cid, 'registered-users'),
-			privileges.categories.give(postingPrivileges, jobPostingsCategory.cid, 'Recruiters')
-		]);
-	});
+    it('recruiters should have posting privileges on job postings category', async () => {
+        const canCreateTopics: boolean = await privileges.categories.can(
+            'topics:create',
+            jobPostingsCategory.cid,
+            recruiterUid
+        ) as boolean;
+        assert(canCreateTopics);
 
-	it('recruiters should have posting privileges on job postings category', async () => {
-		const canCreateTopics = await privileges.categories.can('topics:create',
-			jobPostingsCategory.cid, recruiterUid);
-		assert(canCreateTopics);
+        const canDeleteTopics: boolean = await privileges.categories.can(
+            'topics:delete',
+            jobPostingsCategory.cid,
+            recruiterUid
+        ) as boolean;
+        assert(canDeleteTopics);
 
-		const canDeleteTopics = await privileges.categories.can('topics:delete', 
-			jobPostingsCategory.cid, recruiterUid);
-		assert(canDeleteTopics);
+        const canEditPosts: boolean = await privileges.categories.can(
+            'posts:edit',
+            jobPostingsCategory.cid,
+            recruiterUid
+        ) as boolean;
+        assert(canEditPosts);
 
-		const canEditPosts = await privileges.categories.can('posts:edit',
-			jobPostingsCategory.cid, recruiterUid);
-		assert(canEditPosts);
+        const canDeletePosts: boolean = await privileges.categories.can(
+            'posts:delete',
+            jobPostingsCategory.cid,
+            recruiterUid
+        ) as boolean;
+        assert(canDeletePosts);
+    });
 
-		const canDeletePosts = await privileges.categories.can('posts:delete',
-			jobPostingsCategory.cid, recruiterUid);
-		assert(canDeletePosts);
-	});
+    it('students should not have posting privileges on job postings category', async () => {
+        const canCreateTopics: boolean = await privileges.categories.can(
+            'topics:create',
+            jobPostingsCategory.cid,
+            studentUid
+        ) as boolean;
 
-	it('students should not have posting privileges on job postings category', async () => {
-		const canCreateTopics = await privileges.categories.can('topics:create',
-			jobPostingsCategory.cid, studentUid);
-		assert(!canCreateTopics);
+        assert(!canCreateTopics);
 
-		const canDeleteTopics = await privileges.categories.can('topics:delete',
-			jobPostingsCategory.cid, studentUid);
-		assert(!canDeleteTopics);
+        const canDeleteTopics: boolean = await privileges.categories.can(
+            'topics:delete',
+            jobPostingsCategory.cid,
+            studentUid
+        ) as boolean;
+        assert(!canDeleteTopics);
 
-		const canEditPosts = await privileges.categories.can('posts:edit',
-			jobPostingsCategory.cid, studentUid);
-		assert(!canEditPosts);
+        const canEditPosts: boolean = await privileges.categories.can(
+            'posts:edit',
+            jobPostingsCategory.cid,
+            studentUid
+        ) as boolean;
+        assert(!canEditPosts);
 
-		const canDeletePosts = await privileges.categories.can('posts:delete',
-			jobPostingsCategory.cid, studentUid);
-		assert(!canDeletePosts);
-	});
+        const canDeletePosts: boolean = await privileges.categories.can(
+            'posts:delete',
+            jobPostingsCategory.cid,
+            studentUid
+        ) as boolean;
+        assert(!canDeletePosts);
+    });
 
-	it('admins should have posting privileges on job postings category', async () => {
-		const canCreateTopics = await privileges.categories.can('topics:create',
-			jobPostingsCategory.cid, adminUid);
-		assert(canCreateTopics);
+    it('admins should have posting privileges on job postings category', async () => {
+        const canCreateTopics: boolean = await privileges.categories.can(
+            'topics:create',
+            jobPostingsCategory.cid,
+            adminUid
+        ) as boolean;
+        assert(canCreateTopics);
 
-		const canDeleteTopics = await privileges.categories.can('topics:delete',
-			jobPostingsCategory.cid, adminUid);
-		assert(canDeleteTopics);
+        const canDeleteTopics: boolean = await privileges.categories.can(
+            'topics:delete',
+            jobPostingsCategory.cid,
+            adminUid
+        ) as boolean;
+        assert(canDeleteTopics);
 
-		const canEditPosts = await privileges.categories.can('posts:edit',
-			jobPostingsCategory.cid, adminUid);
-		assert(canEditPosts);
+        const canEditPosts: boolean = await privileges.categories.can(
+            'posts:edit',
+            jobPostingsCategory.cid,
+            adminUid
+        ) as boolean;
+        assert(canEditPosts);
 
-		const canDeletePosts = await privileges.categories.can('posts:delete',
-			jobPostingsCategory.cid, adminUid);
-		assert(canDeletePosts);
-	});
-})
+        const canDeletePosts: boolean = await privileges.categories.can(
+            'posts:delete',
+            jobPostingsCategory.cid,
+            adminUid
+        ) as boolean;
+        assert(canDeletePosts);
+    });
+});


### PR DESCRIPTION
Automatically add all registered users with account type "recruiter" into a Recruiters group.

Allow recruiter type users to create topics under a "Job Postings" category
- Only users in the Recruiters group (and admins) can create posts
- Other users can only view posts

Initialize Recruiters group and Job Postings category on installation.

Testing suite for recruiter functions
- Verify that new recruiters are automatically added to Recruiter group
- Verify permissions for Job Postings category

Closes #12 