### PR TITLE
Add post drafting functionality to save as draft button

### DIFF
--- a/src/plugins/nodebb-plugin-composer-custom/static/lib/composer.js
+++ b/src/plugins/nodebb-plugin-composer-custom/static/lib/composer.js
@@ -830,22 +830,7 @@ define('composer', [
 	};
 
     composer.saveAsDraft = function (post_uuid) {
-		if (composer.posts[post_uuid]) {
-			var postData = composer.posts[post_uuid];
-			var postContainer = $('.composer[data-uuid="' + post_uuid + '"]');
-			postContainer.remove();
-
-			taskbar.discard('composer', post_uuid);
-			$('[data-action="post"]').removeAttr('disabled');
-
-            hooks.fire('action:composer.saveAsDraft'), {
-                post_uuid: post_uuid,
-				postData: postData,
-            }
-			composer.active = undefined;
-		}
-		scheduler.reset();
-		onHide();
+		composer.minimize(post_uuid);
     }
 
 	// Alias to .discard();

--- a/src/plugins/nodebb-plugin-composer-custom/static/lib/composer.js
+++ b/src/plugins/nodebb-plugin-composer-custom/static/lib/composer.js
@@ -837,7 +837,7 @@ define('composer', [
 	};
 
     /* Saves a work in progress post as a draft and closes composer
-    *  input: post_uuid : number
+    *  input: post_uuid : string
     *  output: none
     * */
     composer.saveAsDraft = function (post_uuid) {

--- a/src/plugins/nodebb-plugin-composer-custom/static/lib/composer.js
+++ b/src/plugins/nodebb-plugin-composer-custom/static/lib/composer.js
@@ -355,7 +355,14 @@ define('composer', [
 			});
 		});
 
+        /* JavaScript event listener
+        *  input type : object
+        *  output None
+        *  Calls the save as draft function on a post when the save draft button is clicked
+        *  */
 		postContainer.find('.composer-draft').on('click', function(e) {
+            console.assert(typeof e === "object");
+
 			document.getElementById('panel').style.pointerEvents = 'auto';
 			e.preventDefault();
 
@@ -829,9 +836,14 @@ define('composer', [
 		onHide();
 	};
 
+    /* Saves a work in progress post as a draft and closes composer
+    *  input: post_uuid : number
+    *  output: none
+    * */
     composer.saveAsDraft = function (post_uuid) {
+		console.assert(typeof post_uuid === "string");
 		composer.minimize(post_uuid);
-    }
+    };
 
 	// Alias to .discard();
 	composer.close = composer.discard;

--- a/src/plugins/nodebb-plugin-composer-custom/static/lib/composer.js
+++ b/src/plugins/nodebb-plugin-composer-custom/static/lib/composer.js
@@ -310,7 +310,7 @@ define('composer', [
 			This method enhances a composer container with client-side sugar (preview, etc)
 			Everything in here also applies to the /compose route
 		*/
-
+		document.getElementById('panel').style.pointerEvents = 'panel';
 		if (!post_uuid && !postData) {
 			post_uuid = utils.generateUUID();
 			composer.posts[post_uuid] = ajaxify.data;
@@ -343,7 +343,7 @@ define('composer', [
 		submitBtn.on('click', function (e) {
 			e.preventDefault();
 			e.stopPropagation(); // Other click events bring composer back to active state which is undesired on submit
-
+			document.getElementById('panel').style.pointerEvents = 'panel';
 			$(this).attr('disabled', true);
 			post(post_uuid);
 		});
@@ -355,7 +355,18 @@ define('composer', [
 			});
 		});
 
+		postContainer.find('.composer-draft').on('click', function(e) {
+			document.getElementById('panel').style.pointerEvents = 'auto';
+			e.preventDefault();
+
+			composer.saveAsDraft(post_uuid);
+
+			formatting.exitFullscreen();
+		});
+
+
 		postContainer.find('.composer-discard').on('click', function (e) {
+			document.getElementById('panel').style.pointerEvents = 'auto';
 			e.preventDefault();
 
 			if (!composer.posts[post_uuid].modified) {
@@ -817,6 +828,25 @@ define('composer', [
 		scheduler.reset();
 		onHide();
 	};
+
+    composer.saveAsDraft = function (post_uuid) {
+		if (composer.posts[post_uuid]) {
+			var postData = composer.posts[post_uuid];
+			var postContainer = $('.composer[data-uuid="' + post_uuid + '"]');
+			postContainer.remove();
+
+			taskbar.discard('composer', post_uuid);
+			$('[data-action="post"]').removeAttr('disabled');
+
+            hooks.fire('action:composer.saveAsDraft'), {
+                post_uuid: post_uuid,
+				postData: postData,
+            }
+			composer.active = undefined;
+		}
+		scheduler.reset();
+		onHide();
+    }
 
 	// Alias to .discard();
 	composer.close = composer.discard;

--- a/src/plugins/nodebb-plugin-composer-custom/static/lib/composer/formatting.js
+++ b/src/plugins/nodebb-plugin-composer-custom/static/lib/composer/formatting.js
@@ -57,7 +57,7 @@ define('composer/formatting', [
 					postContainer.find('.write').focus();
 
 					$(window).on('resize', onResize);
-					$(window).one('action:composer.topics.post action:composer.posts.reply action:composer.posts.edit action:composer.discard', screenfull.exit);
+					$(window).one('action:composer.topics.post action:composer.posts.reply action:composer.posts.edit action:composer.discard action:composer.saveAsDraft', screenfull.exit);
 				}
 			});
 

--- a/src/plugins/nodebb-plugin-composer-custom/static/templates/composer.tpl
+++ b/src/plugins/nodebb-plugin-composer-custom/static/templates/composer.tpl
@@ -58,7 +58,7 @@
 
 			<div class="btn-group pull-right action-bar hidden-sm hidden-xs ">
 				<button class="btn btn-default composer-discard" data-action="discard" tabindex="-1"><i class="fa fa-times"></i> [[topic:composer.discard]]</button>
-				<button class="btn btn-success composer-draft" data-action="draft" tabindex="-1"><i class="fa fa-pen"></i> [[topic:composer.draft]]</button>
+				<button class="btn btn-success composer-draft" data-action="saveAsDraft" tabindex="-1"><i class="fa fa-pen"></i> Save as Draft </button>
 				<ul class="dropdown-menu">{{{ each submitOptions }}}<li><a href="#" data-action="{./action}">{./text}</a></li>{{{ end }}}</ul>
 				<button class="btn btn-primary composer-submit" data-action="post" tabindex="6" data-text-variant=" [[topic:composer.schedule]]"><i class="fa fa-check"></i> [[topic:composer.submit]]</button>
 				<button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
Purpose: To add functionality to the "Save as Draft" button in the composer. 

Overview: On a click of the "Save as Draft" button, the post that is a work in progress will be saved as a draft. When you reopen the composer later, it will be populated with the data that was saved. If multiple posts were saved in across multiple topics, a single separate draft will be saved for each topic.

Changes:
- Created a saveAsDraft function which saves the current post being edited as a draft and minimizes the composer
- Added a onClick listener to the "Save as Draft" button which calls the saveAsDraft function
- Add type annotations to new and modified JavaScript functions in nodebb-plugin-composer-custom/static/lib/composer.js.

Resolves #9 