### PR TITLE
Add Retire.js Vulnerability Scanner (Static Analysis)

### DIFF
--- a/.retireignore
+++ b/.retireignore
@@ -1,0 +1,2 @@
+@qs
+node_modules/chart.js/dist/Chart.bundle.min.js

--- a/install/package.json
+++ b/install/package.json
@@ -17,15 +17,15 @@
         "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage"
     },
     "nyc": {
-        "exclude": [
-            "src/upgrades/*",
-            "test/*"
-        ]
+      "exclude": [
+        "src/upgrades/*",
+        "test/*"
+      ]
     },
     "lint-staged": {
-        "*.js": [
-            "eslint --fix"
-        ]
+      "*.js": [
+        "eslint --fix"
+      ]
     },
     "dependencies": {
         "@adactive/bootstrap-tagsinput": "0.8.2",
@@ -172,6 +172,7 @@
         "mocha-lcov-reporter": "1.3.0",
         "mockdate": "3.0.5",
         "nyc": "15.1.0",
+        "retire": "^5.0.0-beta.1",
         "smtp-server": "3.11.0",
         "typescript": "^4.9.4"
     },


### PR DESCRIPTION
RetireJS allows developers to scan the project using "retire" on the command line to output a list of installed dependencies that have security vulnerabilities.

This pull request:
- Adds RetireJS as a dependency in "package.json". 
- Adds an example dependency to ".retireignore" so that the dependency is excluded from the list of vulnerabilities.

Example of a vulnerability scan:
<img width="976" alt="Before-Ignore-Moment" src="https://github.com/CMU-313/spring24-nodebb-c1/assets/59105261/b3be1c3a-c46d-412f-bd35-86175720bace">

You can explicitly list modules to ignore in the scan by editing `.retireignore`.  For example, we can ignore the first "moment.js" vulnerability. (See file change). The result is that "moment.js" is not listed in the output anymore:
<img width="1061" alt="After-Ignore-Moment" src="https://github.com/CMU-313/spring24-nodebb-c1/assets/59105261/2808b7cb-e5bf-41d7-bfd9-f5e2d9cd6d8b">


Here is an example of a recommendation to address a vulnerability:
<img width="976" alt="Reccomendation" src="https://github.com/CMU-313/spring24-nodebb-c1/assets/59105261/11aac779-ba08-4114-af66-364a9133d867">

